### PR TITLE
add commands to release on vsce

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
               run: cd webview-ui && npm ci
 
             - name: Install Publishing Tools
-              run: npm install -g vsce ovsx
+              run: npm install -g vsce
 
             - name: Get Version
               id: get_version
@@ -81,26 +81,23 @@ jobs:
             - name: Package and Publish Extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
-                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
               run: |
                   # Required to generate the .vsix
                   vsce package --out "posthog-extension-${{ steps.get_version.outputs.version }}.vsix"
 
-            # - name: Get Changelog Entry
-            #   id: changelog
-            #   uses: mindsers/changelog-reader-action@v2
-            #   with:
-            #       # This expects a standard Keep a Changelog format
-            #       # "latest" means it will read whichever is the most recent version
-            #       # set in "## [1.2.3] - 2025-01-28" style
-            #       version: latest
+                  if [ "${{ github.event.inputs.release-type }}" = "pre-release" ]; then
+                    npm run publish:marketplace:prerelease
+                    echo "Successfully published pre-release version ${{ steps.get_version.outputs.version }} to VS Code Marketplace"
+                  else
+                    npm run publish:marketplace
+                    echo "Successfully published release version ${{ steps.get_version.outputs.version }} to VS Code Marketplace"
+                  fi
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1
               with:
                   tag_name: ${{ steps.create_tag.outputs.tag }}
                   files: '*.vsix'
-                  # body: ${{ steps.changelog.outputs.content }}
                   generate_release_notes: true
                   prerelease: ${{ github.event.inputs.release-type == 'pre-release' }}
               env:

--- a/package.json
+++ b/package.json
@@ -280,6 +280,8 @@
         "dev:webview": "cd webview-ui && npm run dev",
         "build:webview": "cd webview-ui && npm run build",
         "test:webview": "cd webview-ui && npm run test",
+        "publish:marketplace": "vsce publish",
+        "publish:marketplace:prerelease": "vsce publish --pre-release",
         "prepare": "husky",
         "changeset": "changeset",
         "version-packages": "changeset version"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "PostHog",
     "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
     "version": "1.0.0",
-    "icon": "assets/icons/icon.png",
+    "icon": "assets/icons/posthog-icon.png",
     "engines": {
         "vscode": "^1.84.0",
         "node": ">=16.0.0"


### PR DESCRIPTION
## Problem
The github action was lacking some commands to release on vsce. I have removed ovsx for now, we can add it back later.

## Changes
- Fix commands to release vsix package

## How did you test this code?
Published the extension manually, haven't tested the github action yet
