### PR TITLE
chore: use gitignore for ignoring files, remove .posthogignore

### DIFF
--- a/.posthogignore
+++ b/.posthogignore
@@ -9,3 +9,5 @@ tmp
 .DS_Store
 
 pnpm-lock.yaml
+
+.posthogignore

--- a/.posthogrules
+++ b/.posthogrules
@@ -513,4 +513,4 @@ Contributions to the PostHog extension are welcome! Please follow these guidelin
 
 When adding new tools or API providers, follow the existing patterns in the `src/integrations/` and `src/api/providers/` directories, respectively. Ensure that your code is well-documented and includes appropriate error handling.
 
-The `.posthogignore` file allows users to specify files and directories that PostHog should not access. When implementing new features, respect the `.posthogignore` rules and ensure that your code does not attempt to read or modify ignored files.
+The `.gitignore` file allows users to specify files and directories that PostHog should not access. When implementing new features, respect the rules in `.gitignore` and ensure that your code does not attempt to read or modify ignored files.

--- a/src/core/PostHog.ts
+++ b/src/core/PostHog.ts
@@ -1395,23 +1395,23 @@ export class PostHog {
             }
         }
 
-        const posthogIgnoreContent = this.posthogIgnoreController.posthogIgnoreContent
-        let posthogIgnoreInstructions: string | undefined
-        if (posthogIgnoreContent) {
-            posthogIgnoreInstructions = `# .posthogignore\n\n(The following is provided by a root-level .posthogignore file where the user has specified files and directories that should not be accessed. When using list_files, you'll notice a ${LOCK_TEXT_SYMBOL} next to files that are blocked. Attempting to access the file's contents e.g. through read_file will result in an error.)\n\n${posthogIgnoreContent}\n.posthogignore`
+        const gitIgnoreContent = this.posthogIgnoreController.gitIgnoreContent
+        let gitIgnoreInstructions: string | undefined
+        if (gitIgnoreContent) {
+            gitIgnoreInstructions = `# .gitignore\n\n(The following is provided by a root-level .gitignore file where the user has specified files and directories that should not be accessed. When using list_files, you'll notice a ${LOCK_TEXT_SYMBOL} next to files that are blocked. Attempting to access the file's contents e.g. through read_file will result in an error.)\n\n${gitIgnoreContent}\n.gitignore`
         }
 
         if (
             settingsCustomInstructions ||
             posthogRulesFileInstructions ||
-            posthogIgnoreInstructions ||
+            gitIgnoreInstructions ||
             preferredLanguageInstructions
         ) {
             // altering the system prompt mid-task will break the prompt cache, but in the grand scheme this will not change often so it's better to not pollute user messages with it the way we have to with <potentially relevant details>
             systemPrompt += addUserInstructions(
                 settingsCustomInstructions,
                 posthogRulesFileInstructions,
-                posthogIgnoreInstructions,
+                gitIgnoreInstructions,
                 preferredLanguageInstructions
             )
         }


### PR DESCRIPTION
Let's just use .gitignore for ignoring files, but keep a controller to help us make a best guess attempt at reading/writing only to files that are not ignored.
