### PR TITLE
chore: ask for posthog personal api key on welcome

### DIFF
--- a/src/core/webview/PostHogProvider.ts
+++ b/src/core/webview/PostHogProvider.ts
@@ -67,6 +67,7 @@ type SecretKey =
     | 'sambanovaApiKey'
     | 'inkeepApiKey'
     | 'codestralApiKey'
+    | 'posthogPersonalApiKey'
 type GlobalStateKey =
     | 'apiProvider'
     | 'completionApiProvider'
@@ -114,7 +115,7 @@ type GlobalStateKey =
     | 'thinkingBudgetTokens'
     | 'planActSeparateModelsSetting'
     | 'enableTabAutocomplete'
-
+    | 'posthogHost'
 export class PostHogProvider implements vscode.WebviewViewProvider {
     public static readonly sideBarId = 'posthog.SidebarProvider' // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
     public static readonly tabPanelId = 'posthog.TabPanelProvider'
@@ -1177,6 +1178,8 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
             sambanovaApiKey,
             inkeepApiKey,
             codestralApiKey,
+            posthogPersonalApiKey,
+            posthogHost,
         } = apiConfiguration
         await this.updateGlobalState('apiProvider', apiProvider)
         await this.updateGlobalState('apiModelId', apiModelId)
@@ -1228,6 +1231,8 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
         await this.storeSecret('sambanovaApiKey', sambanovaApiKey)
         await this.storeSecret('inkeepApiKey', inkeepApiKey)
         await this.storeSecret('codestralApiKey', codestralApiKey)
+        await this.storeSecret('posthogPersonalApiKey', posthogPersonalApiKey)
+        await this.updateGlobalState('posthogHost', posthogHost)
         if (this.posthog) {
             this.posthog.api = buildApiHandler(apiConfiguration)
         }
@@ -1934,6 +1939,8 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
             enableTabAutocomplete,
             inkeepApiKey,
             codestralApiKey,
+            posthogPersonalApiKey,
+            posthogHost,
         ] = await Promise.all([
             this.getGlobalState('apiProvider') as Promise<ApiProvider | undefined>,
             this.getGlobalState('completionApiProvider') as Promise<CompletionApiProvider | undefined>,
@@ -2002,6 +2009,8 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
             this.getGlobalState('enableTabAutocomplete') as Promise<boolean | undefined>,
             this.getSecret('inkeepApiKey') as Promise<string | undefined>,
             this.getSecret('codestralApiKey') as Promise<string | undefined>,
+            this.getSecret('posthogPersonalApiKey') as Promise<string | undefined>,
+            this.getGlobalState('posthogHost') as Promise<string | undefined>,
         ])
 
         let apiProvider: ApiProvider
@@ -2100,6 +2109,8 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
                 sambanovaApiKey,
                 inkeepApiKey,
                 codestralApiKey,
+                posthogPersonalApiKey,
+                posthogHost,
             },
             customInstructions,
             taskHistory,
@@ -2248,6 +2259,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
             'sambanovaApiKey',
             'inkeepApiKey',
             'codestralApiKey',
+            'posthogPersonalApiKey',
         ]
         for (const key of secretKeys) {
             await this.storeSecret(key, undefined)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -78,6 +78,8 @@ export interface ApiHandlerOptions {
 export type ApiConfiguration = ApiHandlerOptions & {
     apiProvider?: ApiProvider
     completionApiProvider?: CompletionApiProvider
+    posthogPersonalApiKey?: string
+    posthogHost?: string
 }
 
 // Models

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -61,7 +61,7 @@ const AppContent = () => {
 
     return (
         <>
-            {showWelcome ? (
+            {showWelcome && !showSettings ? (
                 <WelcomeView />
             ) : (
                 <>

--- a/webview-ui/src/components/settings/PostHogConfigOptions.tsx
+++ b/webview-ui/src/components/settings/PostHogConfigOptions.tsx
@@ -1,0 +1,66 @@
+import { VSCodeButton, VSCodeTextField, VSCodeRadioGroup, VSCodeRadio } from '@vscode/webview-ui-toolkit/react'
+import { memo, useState } from 'react'
+import { ApiConfiguration } from '../../../../src/shared/api'
+import { useExtensionState } from '../../context/ExtensionStateContext'
+import VSCodeButtonLink from '../common/VSCodeButtonLink'
+
+const PostHogConfigOptions = () => {
+    const [personalApiKey, setPersonalApiKey] = useState('')
+    const [cloud, setCloud] = useState<'us' | 'eu'>('us')
+    const { apiConfiguration, setApiConfiguration } = useExtensionState()
+
+    const handleSubmit = () => {
+        setApiConfiguration({
+            ...apiConfiguration,
+            posthogPersonalApiKey: personalApiKey,
+            posthogHost: cloud === 'us' ? 'https://us.posthog.com' : 'https://eu.posthog.com',
+        })
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginBottom: 0 }}>
+            <div>
+                <VSCodeTextField
+                    value={personalApiKey}
+                    style={{ width: '100%' }}
+                    type="password"
+                    onInput={(e: any) => setPersonalApiKey(e.target?.value)}
+                    placeholder="Enter PostHog personal API key..."
+                >
+                    <span style={{ fontWeight: 500, marginBottom: 5 }}>PostHog personal API key</span>
+                </VSCodeTextField>
+                <p
+                    style={{
+                        fontSize: '12px',
+                        marginTop: 3,
+                        color: 'var(--vscode-descriptionForeground)',
+                    }}
+                >
+                    This key is stored locally and only used to make API requests from this extension.
+                </p>
+                <VSCodeRadioGroup
+                    value={cloud}
+                    onChange={(e: any) => setCloud(e.target.value)}
+                    style={{ marginTop: 10 }}
+                >
+                    <VSCodeRadio value="us">US Cloud</VSCodeRadio>
+                    <VSCodeRadio value="eu">EU Cloud</VSCodeRadio>
+                </VSCodeRadioGroup>
+                {personalApiKey ? (
+                    <VSCodeButton onClick={handleSubmit} style={{ marginTop: 10, width: '100%' }}>
+                        Save
+                    </VSCodeButton>
+                ) : (
+                    <VSCodeButtonLink
+                        href="https://app.posthog.com/settings/user-api-keys?preset=zapier"
+                        style={{ marginTop: 10, width: '100%' }}
+                    >
+                        Create a PostHog personal API key
+                    </VSCodeButtonLink>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default memo(PostHogConfigOptions)

--- a/webview-ui/src/components/settings/PostHogConfigOptions.tsx
+++ b/webview-ui/src/components/settings/PostHogConfigOptions.tsx
@@ -1,13 +1,14 @@
 import { VSCodeButton, VSCodeTextField, VSCodeRadioGroup, VSCodeRadio } from '@vscode/webview-ui-toolkit/react'
 import { memo, useState } from 'react'
-import { ApiConfiguration } from '../../../../src/shared/api'
 import { useExtensionState } from '../../context/ExtensionStateContext'
 import VSCodeButtonLink from '../common/VSCodeButtonLink'
 
 const PostHogConfigOptions = () => {
-    const [personalApiKey, setPersonalApiKey] = useState('')
-    const [cloud, setCloud] = useState<'us' | 'eu'>('us')
     const { apiConfiguration, setApiConfiguration } = useExtensionState()
+    const [personalApiKey, setPersonalApiKey] = useState(apiConfiguration?.posthogPersonalApiKey)
+    const [cloud, setCloud] = useState<'us' | 'eu'>(
+        apiConfiguration?.posthogHost === 'https://eu.posthog.com' ? 'eu' : 'us'
+    )
 
     const handleSubmit = () => {
         setApiConfiguration({
@@ -52,7 +53,7 @@ const PostHogConfigOptions = () => {
                     </VSCodeButton>
                 ) : (
                     <VSCodeButtonLink
-                        href="https://app.posthog.com/settings/user-api-keys?preset=zapier"
+                        href="https://app.posthog.com/settings/user-api-keys?preset=editor"
                         style={{ marginTop: 10, width: '100%' }}
                     >
                         Create a PostHog personal API key

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -11,6 +11,7 @@ import DocumentationOptions from './DocumentationOptions'
 import AutocompleteOptions from './AutocompleteOptions'
 import AutoApproveMenu from './AutoApproveMenu'
 import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from '../../utils/vscStyles'
+import PostHogConfigOptions from './PostHogConfigOptions'
 const { IS_DEV } = process.env
 
 type SettingsTab = 'privacy' | 'rules' | 'api' | 'features' | 'advanced'
@@ -67,7 +68,7 @@ const SettingsView = () => {
         // uses someVar and anotherVar
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [someVar])
-	If we only want to run code once on mount we can use react-use's useEffectOnce or useMount
+    If we only want to run code once on mount we can use react-use's useEffectOnce or useMount
     */
 
     const handleMessage = useCallback(
@@ -258,7 +259,19 @@ const SettingsView = () => {
 
     const FeaturesSettings = () => (
         <>
-            <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginBottom: '5px' }}>Auto-Approval</h3>
+            <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginBottom: '5px' }}>PostHog Configuration</h3>
+            <div
+                style={{
+                    height: '0.5px',
+                    background: getAsVar(VSC_TITLEBAR_INACTIVE_FOREGROUND),
+                    marginBottom: '15px',
+                    opacity: 0.2,
+                }}
+            />
+            <PostHogConfigOptions />
+            <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginTop: '5px', marginBottom: '5px' }}>
+                Auto-Approval
+            </h3>
             <AutoApproveMenu />
             <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginBottom: '5px', marginTop: '5px' }}>
                 Auto-Complete

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -14,7 +14,7 @@ import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from '../../utils/vscStyle
 import PostHogConfigOptions from './PostHogConfigOptions'
 const { IS_DEV } = process.env
 
-type SettingsTab = 'privacy' | 'rules' | 'api' | 'features' | 'advanced'
+type SettingsTab = 'privacy' | 'rules' | 'api' | 'general' | 'advanced'
 
 const SettingsView = () => {
     const {
@@ -32,7 +32,7 @@ const SettingsView = () => {
     const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
     const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
     const [pendingTabChange, setPendingTabChange] = useState<'plan' | 'act' | null>(null)
-    const [activeTab, setActiveTab] = useState<SettingsTab>('features')
+    const [activeTab, setActiveTab] = useState<SettingsTab>('general')
 
     const handleSubmit = () => {
         const apiValidationResult = validateApiConfiguration(apiConfiguration)
@@ -123,7 +123,7 @@ const SettingsView = () => {
         </button>
     )
 
-    const GeneralSettings = () => (
+    const PrivacySettings = () => (
         <>
             <div style={{ marginBottom: 5 }}>
                 <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginBottom: '5px' }}>Telemetry</h3>
@@ -257,7 +257,7 @@ const SettingsView = () => {
         </>
     )
 
-    const FeaturesSettings = () => (
+    const GeneralSettings = () => (
         <>
             <h3 style={{ color: 'var(--vscode-foreground)', margin: 0, marginBottom: '5px' }}>PostHog Configuration</h3>
             <div
@@ -355,8 +355,8 @@ const SettingsView = () => {
                         flexDirection: 'column',
                     }}
                 >
-                    <MenuButton tab="features" label="Features" />
-                    <MenuButton tab="api" label="API Configuration" />
+                    <MenuButton tab="general" label="General" />
+                    <MenuButton tab="api" label="Provider Configuration" />
                     <MenuButton tab="rules" label="Rules" />
                     <MenuButton tab="privacy" label="Privacy" />
                     <MenuButton tab="advanced" label="Advanced" />
@@ -372,8 +372,8 @@ const SettingsView = () => {
                 >
                     {activeTab === 'rules' && <RulesSettings />}
                     {activeTab === 'api' && <ApiSettings />}
-                    {activeTab === 'features' && <FeaturesSettings />}
-                    {activeTab === 'privacy' && <GeneralSettings />}
+                    {activeTab === 'general' && <GeneralSettings />}
+                    {activeTab === 'privacy' && <PrivacySettings />}
                     {activeTab === 'advanced' && IS_DEV && <AdvancedSettings />}
 
                     {/* Version info at the bottom */}

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -16,10 +16,7 @@ const WelcomeView = () => {
     const disableLetsGoButton = apiErrorMessage != null
 
     const handleSubmit = () => {
-        setApiConfiguration({
-            ...apiConfiguration,
-            apiKey: 'test',
-        })
+        vscode.postMessage({ type: 'apiConfiguration', apiConfiguration })
     }
 
     useEffect(() => {

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+import { VSCodeButton, VSCodeDivider } from '@vscode/webview-ui-toolkit/react'
 import { useEffect, useState } from 'react'
 import { useExtensionState } from '../../context/ExtensionStateContext'
 import { validateApiConfiguration } from '../../utils/validate'
@@ -6,21 +6,29 @@ import { vscode } from '../../utils/vscode'
 import ApiOptions from '../settings/ApiOptions'
 import PostHogLogoWhite from '../../assets/PostHogLogoWhite'
 import AutocompleteOptions from '../settings/AutocompleteOptions'
+import PostHogConfigOptions from '../settings/PostHogConfigOptions'
 
 const WelcomeView = () => {
-    const { apiConfiguration } = useExtensionState()
+    const { apiConfiguration, setApiConfiguration } = useExtensionState()
     const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
     const [showApiOptions, setShowApiOptions] = useState(false)
 
     const disableLetsGoButton = apiErrorMessage != null
 
     const handleSubmit = () => {
-        vscode.postMessage({ type: 'apiConfiguration', apiConfiguration })
+        setApiConfiguration({
+            ...apiConfiguration,
+            apiKey: 'test',
+        })
     }
 
     useEffect(() => {
         setApiErrorMessage(validateApiConfiguration(apiConfiguration))
     }, [apiConfiguration])
+
+    const hasPersonalApiKey = !!apiConfiguration?.posthogPersonalApiKey
+
+    console.log('hasPersonalApiKey', hasPersonalApiKey)
 
     return (
         <div
@@ -46,49 +54,56 @@ const WelcomeView = () => {
                 <div style={{ display: 'flex', justifyContent: 'center', margin: '20px 0' }}>
                     <PostHogLogoWhite className="size-16" />
                 </div>
-                <p>
-                    I can do all kinds of tasks thanks to breakthroughs in{' '}
-                    <VSCodeLink href="https://www.anthropic.com/claude/sonnet" style={{ display: 'inline' }}>
-                        Claude 3.7 Sonnet's
-                    </VSCodeLink>
-                    agentic coding capabilities and access to tools that let me create & edit files, explore complex
-                    projects, use a browser, and execute terminal commands <i>(with your permission, of course)</i>. I
-                    can even use MCP to create new tools and extend my own capabilities.
-                </p>
+                <p>I'm here to help you build a successful product.</p>
+                <p>I can help you write code and respond to questions about your product and users.</p>
+                <p>Let's get started.</p>
+                <VSCodeDivider style={{ margin: '20px 0' }} />
 
-                <p style={{ color: 'var(--vscode-descriptionForeground)' }}>
-                    Sign up for an account to get started for free, or use an API key that provides access to models
-                    like Claude 3.7 Sonnet.
-                </p>
+                {!hasPersonalApiKey && <PostHogConfigOptions />}
 
-                {!showApiOptions && (
-                    <VSCodeButton
-                        appearance="secondary"
-                        onClick={() => setShowApiOptions(!showApiOptions)}
-                        style={{ marginTop: 10, width: '100%' }}
-                    >
-                        Use your own API key
-                    </VSCodeButton>
-                )}
+                {hasPersonalApiKey && (
+                    <>
+                        <VSCodeButton
+                            onClick={() => {
+                                setApiConfiguration({
+                                    ...apiConfiguration,
+                                    apiKey: 'test',
+                                })
+                            }}
+                        >
+                            Use test API key
+                        </VSCodeButton>
 
-                <div style={{ marginTop: '18px' }}>
-                    {showApiOptions && (
-                        <div>
-                            <ApiOptions showModelOptions={false} />
-                            <AutocompleteOptions />
+                        {!showApiOptions && (
                             <VSCodeButton
-                                onClick={handleSubmit}
-                                disabled={disableLetsGoButton}
-                                style={{ marginTop: '3px' }}
+                                appearance="secondary"
+                                onClick={() => setShowApiOptions(!showApiOptions)}
+                                style={{ marginTop: 10, width: '100%' }}
                             >
-                                Let's go!
+                                Use your own API key
                             </VSCodeButton>
-                            {apiErrorMessage && (
-                                <p style={{ color: 'var(--vscode-errorForeground)' }}>{apiErrorMessage}</p>
+                        )}
+
+                        <div style={{ marginTop: '18px' }}>
+                            {showApiOptions && (
+                                <div>
+                                    <ApiOptions showModelOptions={false} />
+                                    <AutocompleteOptions />
+                                    <VSCodeButton
+                                        onClick={handleSubmit}
+                                        disabled={disableLetsGoButton}
+                                        style={{ marginTop: '3px' }}
+                                    >
+                                        Let's go!
+                                    </VSCodeButton>
+                                    {apiErrorMessage && (
+                                        <p style={{ color: 'var(--vscode-errorForeground)' }}>{apiErrorMessage}</p>
+                                    )}
+                                </div>
                             )}
                         </div>
-                    )}
-                </div>
+                    </>
+                )}
             </div>
         </div>
     )

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -28,8 +28,6 @@ const WelcomeView = () => {
 
     const hasPersonalApiKey = !!apiConfiguration?.posthogPersonalApiKey
 
-    console.log('hasPersonalApiKey', hasPersonalApiKey)
-
     return (
         <div
             style={{

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -90,10 +90,11 @@ export const ExtensionStateContextProvider: React.FC<{
                           config.xaiApiKey,
                           config.sambanovaApiKey,
                           config.codestralApiKey,
-                          config.posthogPersonalApiKey,
                       ].some((key) => key !== undefined)
                     : false
-                setShowWelcome(!hasKey)
+
+                const hasPersonalApiKey = config?.posthogPersonalApiKey !== undefined
+                setShowWelcome(!hasKey || !hasPersonalApiKey)
                 setDidHydrateState(true)
                 break
             }

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -90,6 +90,7 @@ export const ExtensionStateContextProvider: React.FC<{
                           config.xaiApiKey,
                           config.sambanovaApiKey,
                           config.codestralApiKey,
+                          config.posthogPersonalApiKey,
                       ].some((key) => key !== undefined)
                     : false
                 setShowWelcome(!hasKey)


### PR DESCRIPTION
### Description

User needs a PostHog personal api key for accessing PostHog data from the extension. This adds a check to the welcome view so that user can add an api key and provides a link to a preset.
