### PR TITLE
feat: conf as shared service

### DIFF
--- a/src/core/webview/PostHogProvider.ts
+++ b/src/core/webview/PostHogProvider.ts
@@ -1,6 +1,5 @@
 import { Anthropic } from '@anthropic-ai/sdk'
 import axios from 'axios'
-import crypto from 'crypto'
 import { execa } from 'execa'
 import fs from 'fs/promises'
 import os from 'os'
@@ -13,18 +12,8 @@ import { selectImages } from '../../integrations/misc/process-images'
 import { getTheme } from '../../integrations/theme/getTheme'
 import WorkspaceTracker from '../../integrations/workspace/WorkspaceTracker'
 import { McpHub } from '../../services/mcp/McpHub'
-import { UserInfo } from '../../shared/UserInfo'
-import {
-    allModels,
-    anthropicDefaultModelId,
-    ApiConfiguration,
-    ApiProvider,
-    CompletionApiProvider,
-    ModelInfo,
-} from '../../shared/api'
+import { ApiConfiguration } from '../../shared/api'
 import { findLast } from '../../shared/array'
-import { AutoApprovalSettings, DEFAULT_AUTO_APPROVAL_SETTINGS } from '../../shared/AutoApprovalSettings'
-import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from '../../shared/BrowserSettings'
 import { ChatContent } from '../../shared/ChatContent'
 import { ChatSettings } from '../../shared/ChatSettings'
 import { ExtensionMessage, ExtensionState, Invoke, Platform } from '../../shared/ExtensionMessage'
@@ -39,14 +28,14 @@ import { getUri } from './getUri'
 import { telemetryService } from '../../services/telemetry/TelemetryService'
 import { TelemetrySetting } from '../../shared/TelemetrySetting'
 import { cleanupLegacyCheckpoints } from '../../integrations/checkpoints/CheckpointMigration'
-import CheckpointTracker from '../../integrations/checkpoints/CheckpointTracker'
 import { getTotalTasksSize } from '../../utils/storage'
 import { GlobalFileNames } from '../../global-constants'
 import { setTimeout as setTimeoutPromise } from 'node:timers/promises'
-import { getStatusBarStatus, setupStatusBar, StatusBarStatus } from '../../autocomplete/statusBar'
+import { setupStatusBar, StatusBarStatus } from '../../autocomplete/statusBar'
 import { PostHogApiProvider } from '../../api/provider'
 import { PostHogClient } from '../../api/posthogClient'
 import { getHost } from '../../api/utils/host'
+import { ConfigManager } from '../../shared/conf'
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
 
@@ -69,6 +58,7 @@ type GlobalStateKey =
     | 'enableTabAutocomplete'
     | 'posthogHost'
     | 'posthogProjectId'
+
 export class PostHogProvider implements vscode.WebviewViewProvider {
     public static readonly sideBarId = 'posthog.SidebarProvider' // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
     public static readonly tabPanelId = 'posthog.TabPanelProvider'
@@ -77,17 +67,20 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     private activeWebviews: Set<vscode.WebviewView | vscode.WebviewPanel> = new Set()
     private view?: vscode.WebviewView | vscode.WebviewPanel
     private posthog?: PostHog
+    private readonly configManager: ConfigManager
     workspaceTracker?: WorkspaceTracker
     mcpHub?: McpHub
 
     constructor(
         readonly context: vscode.ExtensionContext,
-        private readonly outputChannel: vscode.OutputChannel
+        private readonly outputChannel: vscode.OutputChannel,
+        configManager: ConfigManager
     ) {
         this.outputChannel.appendLine('PostHogProvider instantiated')
         PostHogProvider.activeInstances.add(this)
         this.workspaceTracker = new WorkspaceTracker(this)
         this.mcpHub = new McpHub(this)
+        this.configManager = configManager
 
         // Clean up legacy checkpoints
         cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
@@ -127,7 +120,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     // Auth methods
     async handleSignOut() {
         try {
-            await this.updateGlobalState('apiProvider', 'openrouter')
+            await this.configManager.setGlobalValue('apiProvider', 'openrouter')
             await this.postStateToWebview()
             vscode.window.showInformationMessage('Successfully logged out of PostHog')
         } catch (error) {
@@ -136,7 +129,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     }
 
     async setUserInfo(info?: { displayName: string | null; email: string | null; photoURL: string | null }) {
-        await this.updateGlobalState('userInfo', info)
+        await this.configManager.setGlobalValue('userInfo', info)
     }
 
     public static getVisibleInstance(): PostHogProvider | undefined {
@@ -339,7 +332,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     async initPostHogWithTask(task?: string, images?: string[]) {
         await this.clearTask() // ensures that an existing task doesn't exist before starting a new one, although this shouldn't be possible since user must clear task before starting a new one
         const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings, chatSettings } =
-            await this.getState()
+            await this.configManager.loadState()
         this.posthog = new PostHog(
             this,
             apiConfiguration,
@@ -355,7 +348,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     async initPostHogWithHistoryItem(historyItem: HistoryItem) {
         await this.clearTask()
         const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings, chatSettings } =
-            await this.getState()
+            await this.configManager.loadState()
         this.posthog = new PostHog(
             this,
             apiConfiguration,
@@ -565,7 +558,10 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
                         break
                     case 'autoApprovalSettings':
                         if (message.autoApprovalSettings) {
-                            await this.updateGlobalState('autoApprovalSettings', message.autoApprovalSettings)
+                            await this.configManager.setGlobalValue(
+                                'autoApprovalSettings',
+                                message.autoApprovalSettings
+                            )
                             if (this.posthog) {
                                 this.posthog.autoApprovalSettings = message.autoApprovalSettings
                             }
@@ -574,7 +570,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
                         break
                     case 'browserSettings':
                         if (message.browserSettings) {
-                            await this.updateGlobalState('browserSettings', message.browserSettings)
+                            await this.configManager.setGlobalValue('browserSettings', message.browserSettings)
                             if (this.posthog) {
                                 this.posthog.updateBrowserSettings(message.browserSettings)
                             }
@@ -842,7 +838,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
                         break
                     }
                     case 'loadPosthogProjects': {
-                        const { apiConfiguration } = await this.getState()
+                        const { apiConfiguration } = await this.configManager.loadState()
                         const posthogClient = new PostHogClient(
                             getHost(apiConfiguration),
                             apiConfiguration.posthogApiKey
@@ -862,14 +858,14 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     }
 
     async updateTelemetrySetting(telemetrySetting: TelemetrySetting) {
-        await this.updateGlobalState('telemetrySetting', telemetrySetting)
+        await this.configManager.setGlobalValue('telemetrySetting', telemetrySetting)
         const isOptedIn = telemetrySetting === 'enabled'
         telemetryService.updateTelemetryState(isOptedIn)
     }
 
     async toggleEnableTabAutocomplete(enableTabAutocomplete: boolean) {
         console.log('toggleEnableTabAutocomplete', enableTabAutocomplete)
-        await this.updateGlobalState('enableTabAutocomplete', enableTabAutocomplete)
+        await this.configManager.setGlobalValue('enableTabAutocomplete', enableTabAutocomplete)
         telemetryService.captureAutocompleteEnabled()
         if (enableTabAutocomplete) {
             setupStatusBar(StatusBarStatus.Enabled)
@@ -884,24 +880,25 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
         // Capture mode switch telemetry | Capture regardless of if we know the taskId
         telemetryService.captureModeSwitch(this.posthog?.taskId ?? '0', mode)
 
-        const { chatSettings } = await this.getState()
+        const { chatSettings } = await this.configManager.loadState()
 
         const currentModeChatSettings = chatSettings[mode]
-        this.updateGlobalState('apiProvider', currentModeChatSettings.apiProvider)
-        this.updateGlobalState('apiModelId', currentModeChatSettings.apiModelId)
-        this.updateGlobalState('thinkingEnabled', currentModeChatSettings.thinkingEnabled)
+        this.configManager.setGlobalValue('apiProvider', currentModeChatSettings.apiProvider)
+        this.configManager.setGlobalValue('apiModelId', currentModeChatSettings.apiModelId)
+        this.configManager.setGlobalValue('thinkingEnabled', currentModeChatSettings.thinkingEnabled)
 
         if (this.posthog) {
-            const { apiConfiguration: updatedApiConfiguration } = await this.getState()
-            this.posthog.api = new PostHogApiProvider(
-                updatedApiConfiguration.apiModelId,
-                updatedApiConfiguration.posthogHost,
-                updatedApiConfiguration.posthogApiKey,
-                updatedApiConfiguration.thinkingEnabled
-            )
+            const { apiConfiguration: updatedApiConfiguration } = await this.configManager.loadState()
+            if (updatedApiConfiguration.apiModelId) {
+                this.posthog.api = new PostHogApiProvider(
+                    updatedApiConfiguration.apiModelId,
+                    updatedApiConfiguration.posthogHost,
+                    updatedApiConfiguration.posthogApiKey,
+                    updatedApiConfiguration.thinkingEnabled
+                )
+            }
         }
-
-        await this.updateGlobalState('chatSettings', {
+        await this.configManager.setGlobalValue('chatSettings', {
             ...chatSettings,
             mode,
         })
@@ -955,35 +952,16 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
 
     async updateCustomInstructions(instructions?: string) {
         // User may be clearing the field
-        await this.updateGlobalState('customInstructions', instructions || undefined)
+        await this.configManager.setGlobalValue('customInstructions', instructions || undefined)
         if (this.posthog) {
             this.posthog.customInstructions = instructions || undefined
         }
     }
 
     async updateApiConfiguration(apiConfiguration: ApiConfiguration) {
-        const { apiProvider, apiModelId, posthogApiKey, thinkingEnabled, posthogHost, posthogProjectId } =
-            apiConfiguration
-        if (apiProvider) {
-            await this.updateGlobalState('apiProvider', apiProvider)
-        }
-        if (apiModelId) {
-            await this.updateGlobalState('apiModelId', apiModelId)
-        }
-        if (posthogHost) {
-            await this.updateGlobalState('posthogHost', posthogHost)
-        }
-        if (posthogApiKey) {
-            await this.storeSecret('posthogApiKey', posthogApiKey)
-        }
-        if (thinkingEnabled !== undefined) {
-            await this.updateGlobalState('thinkingEnabled', thinkingEnabled)
-        }
-        if (posthogProjectId) {
-            await this.updateGlobalState('posthogProjectId', posthogProjectId)
-        }
-        const { apiConfiguration: updatedApiConfiguration } = await this.getState()
-        if (this.posthog) {
+        await this.configManager.updateApiConfiguration(apiConfiguration)
+        const { apiConfiguration: updatedApiConfiguration } = await this.configManager.loadState()
+        if (this.posthog && updatedApiConfiguration.apiModelId) {
             this.posthog.api = new PostHogApiProvider(
                 updatedApiConfiguration.apiModelId,
                 updatedApiConfiguration.posthogHost,
@@ -994,7 +972,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     }
 
     async updateChatSettings(chatSettings: ChatSettings) {
-        await this.updateGlobalState('chatSettings', chatSettings)
+        await this.configManager.setGlobalValue('chatSettings', chatSettings)
         await this.updateApiConfiguration(chatSettings[chatSettings.mode])
         if (this.posthog) {
             this.posthog.updateChatSettings(chatSettings)
@@ -1163,7 +1141,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
         uiMessagesFilePath: string
         apiConversationHistory: Anthropic.MessageParam[]
     }> {
-        const history = ((await this.getGlobalState('taskHistory')) as HistoryItem[] | undefined) || []
+        const history = (await this.configManager.getGlobalValue<HistoryItem[]>('taskHistory')) || []
         const historyItem = history.find((item) => item.id === id)
         if (historyItem) {
             const taskDirPath = path.join(this.context.globalStorageUri.fsPath, 'tasks', id)
@@ -1201,7 +1179,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
 
     async deleteAllTaskHistory() {
         await this.clearTask()
-        await this.updateGlobalState('taskHistory', undefined)
+        await this.configManager.setGlobalValue('taskHistory', undefined)
         try {
             // Remove all contents of tasks directory
             const taskDirPath = path.join(this.context.globalStorageUri.fsPath, 'tasks')
@@ -1275,9 +1253,9 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
 
     async deleteTaskFromState(id: string) {
         // Remove the task from history
-        const taskHistory = ((await this.getGlobalState('taskHistory')) as HistoryItem[] | undefined) || []
+        const taskHistory = (await this.configManager.getGlobalValue<HistoryItem[]>('taskHistory')) || []
         const updatedTaskHistory = taskHistory.filter((task) => task.id !== id)
-        await this.updateGlobalState('taskHistory', updatedTaskHistory)
+        await this.configManager.setGlobalValue('taskHistory', updatedTaskHistory)
 
         // Notify the webview that the task has been deleted
         await this.postStateToWebview()
@@ -1305,7 +1283,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
             userInfo,
             telemetrySetting,
             enableTabAutocomplete,
-        } = await this.getState()
+        } = await this.configManager.loadState()
 
         return {
             version: this.context.extension?.packageJSON?.version ?? '',
@@ -1356,7 +1334,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     */
 
     // getApiConversationHistory(): Anthropic.MessageParam[] {
-    // 	// const history = (await this.getGlobalState(
+    // 	// const history = (await this.getGlobalValue(
     // 	// 	this.getApiConversationHistoryStateKey()
     // 	// )) as Anthropic.MessageParam[]
     // 	// return history || []
@@ -1364,7 +1342,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     // }
 
     // setApiConversationHistory(history: Anthropic.MessageParam[] | undefined) {
-    // 	// await this.updateGlobalState(this.getApiConversationHistoryStateKey(), history)
+    // 	// await this.configManager.setGlobalValue(this.getApiConversationHistoryStateKey(), history)
     // 	this.apiConversationHistory = history || []
     // }
 
@@ -1377,147 +1355,16 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     // 	return this.apiConversationHistory
     // }
 
-    /*
-    Storage
-    https://dev.to/kompotkot/how-to-use-secretstorage-in-your-vscode-extensions-2hco
-    https://www.eliostruyf.com/devhack-code-extension-storage-options/
-    */
-
-    async getState() {
-        const [
-            storedApiProvider,
-            storedCompletionApiProvider,
-            storedApiModelId,
-            posthogApiKey,
-            customInstructions,
-            taskHistory,
-            autoApprovalSettings,
-            browserSettings,
-            storedChatSettings,
-            userInfo,
-            telemetrySetting,
-            thinkingEnabled,
-            enableTabAutocomplete,
-            storedPostHogHost,
-            posthogProjectId,
-        ] = await Promise.all([
-            this.getGlobalState('apiProvider') as Promise<ApiProvider | undefined>,
-            this.getGlobalState('completionApiProvider') as Promise<CompletionApiProvider | undefined>,
-            this.getGlobalState('apiModelId') as Promise<string | undefined>,
-            this.getSecret('posthogApiKey') as Promise<string | undefined>,
-            this.getGlobalState('customInstructions') as Promise<string | undefined>,
-            this.getGlobalState('taskHistory') as Promise<HistoryItem[] | undefined>,
-            this.getGlobalState('autoApprovalSettings') as Promise<AutoApprovalSettings | undefined>,
-            this.getGlobalState('browserSettings') as Promise<BrowserSettings | undefined>,
-            this.getGlobalState('chatSettings') as Promise<ChatSettings | undefined>,
-            this.getGlobalState('userInfo') as Promise<UserInfo | undefined>,
-            this.getGlobalState('telemetrySetting') as Promise<TelemetrySetting | undefined>,
-            this.getGlobalState('thinkingEnabled') as Promise<boolean | undefined>,
-            this.getGlobalState('enableTabAutocomplete') as Promise<boolean | undefined>,
-            this.getGlobalState('posthogHost') as Promise<string | undefined>,
-            this.getGlobalState('posthogProjectId') as Promise<string | undefined>,
-        ])
-
-        let apiProvider: ApiProvider
-        if (storedApiProvider) {
-            apiProvider = storedApiProvider
-        } else {
-            // Either new user or legacy user that doesn't have the apiProvider stored in state
-            apiProvider = 'anthropic'
-        }
-        let apiModelId: keyof typeof allModels
-        if (storedApiModelId) {
-            apiModelId = storedApiModelId as keyof typeof allModels
-        } else {
-            apiModelId = anthropicDefaultModelId
-        }
-        let completionApiProvider: CompletionApiProvider
-        if (storedCompletionApiProvider) {
-            completionApiProvider = storedCompletionApiProvider
-        } else {
-            completionApiProvider = 'codestral'
-        }
-        let posthogHost: string
-        if (storedPostHogHost) {
-            posthogHost = storedPostHogHost
-        } else {
-            posthogHost = 'https://us.posthog.com'
-        }
-        let chatSettings: ChatSettings
-        if (storedChatSettings) {
-            chatSettings = storedChatSettings
-            // ensure all modes are present
-            for (const mode of ['ask', 'plan', 'act'] as const) {
-                if (chatSettings[mode] === undefined) {
-                    chatSettings[mode] = {
-                        apiProvider,
-                        apiModelId,
-                        thinkingEnabled,
-                    }
-                }
-            }
-        } else {
-            chatSettings = {
-                mode: 'ask',
-                ask: {
-                    apiProvider,
-                    apiModelId,
-                    thinkingEnabled,
-                },
-                plan: {
-                    apiProvider,
-                    apiModelId,
-                    thinkingEnabled,
-                },
-                act: {
-                    apiProvider,
-                    apiModelId,
-                    thinkingEnabled,
-                },
-            }
-        }
-
-        return {
-            apiConfiguration: {
-                apiProvider,
-                completionApiProvider,
-                apiModelId,
-                posthogHost,
-                posthogApiKey,
-                posthogProjectId,
-                thinkingEnabled,
-            },
-            customInstructions,
-            taskHistory,
-            autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
-            browserSettings: browserSettings || DEFAULT_BROWSER_SETTINGS,
-            chatSettings,
-            userInfo,
-            telemetrySetting: telemetrySetting || 'unset',
-            enableTabAutocomplete,
-        }
-    }
-
     async updateTaskHistory(item: HistoryItem): Promise<HistoryItem[]> {
-        const history = ((await this.getGlobalState('taskHistory')) as HistoryItem[]) || []
+        const history = (await this.configManager.getGlobalValue<HistoryItem[]>('taskHistory')) || []
         const existingItemIndex = history.findIndex((h) => h.id === item.id)
         if (existingItemIndex !== -1) {
             history[existingItemIndex] = item
         } else {
             history.push(item)
         }
-        await this.updateGlobalState('taskHistory', history)
+        await this.configManager.setGlobalValue('taskHistory', history)
         return history
-    }
-
-    // global
-
-    async updateGlobalState(key: GlobalStateKey, value: any) {
-        await this.context.globalState.update(key, value)
-    }
-
-    async getGlobalState(key: GlobalStateKey) {
-        return await this.context.globalState.get(key)
     }
 
     // private async clearState() {
@@ -1531,18 +1378,6 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
     // }
 
     // secrets
-
-    private async storeSecret(key: SecretKey, value?: string) {
-        if (value) {
-            await this.context.secrets.store(key, value)
-        } else {
-            await this.context.secrets.delete(key)
-        }
-    }
-
-    async getSecret(key: SecretKey) {
-        return await this.context.secrets.get(key)
-    }
 
     // Open Graph Data
 
@@ -1595,13 +1430,7 @@ export class PostHogProvider implements vscode.WebviewViewProvider {
 
     async resetState() {
         vscode.window.showInformationMessage('Resetting state...')
-        for (const key of this.context.globalState.keys()) {
-            await this.context.globalState.update(key, undefined)
-        }
-        const secretKeys: SecretKey[] = ['posthogApiKey']
-        for (const key of secretKeys) {
-            await this.storeSecret(key, undefined)
-        }
+        await this.configManager.clearAllData()
         if (this.posthog) {
             this.posthog.abortTask()
             this.posthog = undefined

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -1,8 +1,13 @@
 import * as vscode from 'vscode'
 import { PostHogAPI } from './posthog'
 import { PostHogProvider } from '../core/webview/PostHogProvider'
+import { ConfigManager } from '../shared/conf'
 
-export function createPostHogAPI(outputChannel: vscode.OutputChannel, sidebarProvider: PostHogProvider): PostHogAPI {
+export function createPostHogAPI(
+    outputChannel: vscode.OutputChannel,
+    sidebarProvider: PostHogProvider,
+    configManager: ConfigManager
+): PostHogAPI {
     const api: PostHogAPI = {
         setCustomInstructions: async (value: string) => {
             await sidebarProvider.updateCustomInstructions(value)
@@ -10,7 +15,7 @@ export function createPostHogAPI(outputChannel: vscode.OutputChannel, sidebarPro
         },
 
         getCustomInstructions: async () => {
-            return (await sidebarProvider.getGlobalState('customInstructions')) as string | undefined
+            return (await configManager.getGlobalValue('customInstructions')) as string | undefined
         },
 
         startNewTask: async (task?: string, images?: string[]) => {

--- a/src/shared/conf.ts
+++ b/src/shared/conf.ts
@@ -1,0 +1,229 @@
+import { ExtensionContext } from 'vscode'
+import { AutoApprovalSettings, DEFAULT_AUTO_APPROVAL_SETTINGS } from './AutoApprovalSettings'
+import { allModels, anthropicDefaultModelId, ApiConfiguration } from './api'
+import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from './BrowserSettings'
+import { ApiProvider, CompletionApiProvider } from './api'
+import { HistoryItem } from './HistoryItem'
+import { ChatSettings } from './ChatSettings'
+import { TelemetrySetting } from './TelemetrySetting'
+import { UserInfo } from './UserInfo'
+
+type SecretKey = 'posthogApiKey'
+
+type GlobalStateKey =
+    | 'apiProvider'
+    | 'completionApiProvider'
+    | 'apiModelId'
+    | 'customInstructions'
+    | 'taskHistory'
+    | 'autoApprovalSettings'
+    | 'browserSettings'
+    | 'chatSettings'
+    | 'userInfo'
+    | 'telemetrySetting'
+    | 'thinkingEnabled'
+    | 'enableTabAutocomplete'
+    | 'posthogHost'
+    | 'posthogProjectId'
+
+export interface ExtensionStorageState {
+    apiConfiguration: ApiConfiguration
+    customInstructions?: string
+    taskHistory?: HistoryItem[]
+    autoApprovalSettings: AutoApprovalSettings
+    browserSettings: BrowserSettings
+    chatSettings: ChatSettings
+    userInfo?: UserInfo
+    telemetrySetting: TelemetrySetting
+    enableTabAutocomplete?: boolean
+}
+
+export class ConfigManager {
+    private _cachedState: ExtensionStorageState | undefined
+
+    constructor(private readonly context: ExtensionContext) {}
+
+    async init(): Promise<ExtensionStorageState> {
+        if (this._cachedState) {
+            throw new Error('Already initialized.')
+        }
+        this._cachedState = await this.loadState()
+        return this._cachedState
+    }
+
+    get currentState() {
+        if (!this._cachedState) {
+            throw new Error('ExtensionStorage not initialized')
+        }
+        return this._cachedState
+    }
+
+    getGlobalValue<T>(key: GlobalStateKey): T | undefined {
+        return this.context.globalState.get<T>(key)
+    }
+
+    async setGlobalValue(key: GlobalStateKey, value: any) {
+        await this.context.globalState.update(key, value)
+    }
+
+    async getSecretValue(key: SecretKey): Promise<string | undefined> {
+        return await this.context.secrets.get(key)
+    }
+
+    async setSecretValue(key: SecretKey, value: string) {
+        await this.context.secrets.store(key, value)
+    }
+
+    async deleteSecretValue(key: SecretKey) {
+        await this.context.secrets.delete(key)
+    }
+
+    async loadState(): Promise<ExtensionStorageState> {
+        const [
+            storedApiProvider,
+            storedCompletionApiProvider,
+            storedApiModelId,
+            posthogApiKey,
+            customInstructions,
+            taskHistory,
+            autoApprovalSettings,
+            browserSettings,
+            storedChatSettings,
+            userInfo,
+            telemetrySetting,
+            thinkingEnabled,
+            enableTabAutocomplete,
+            storedPostHogHost,
+            posthogProjectId,
+        ] = await Promise.all([
+            this.getGlobalValue<ApiProvider>('apiProvider'),
+            this.getGlobalValue<CompletionApiProvider>('completionApiProvider'),
+            this.getGlobalValue<string>('apiModelId'),
+            this.getSecretValue('posthogApiKey'),
+            this.getGlobalValue<string>('customInstructions'),
+            this.getGlobalValue<HistoryItem[]>('taskHistory'),
+            this.getGlobalValue<AutoApprovalSettings>('autoApprovalSettings'),
+            this.getGlobalValue<BrowserSettings>('browserSettings'),
+            this.getGlobalValue<ChatSettings>('chatSettings'),
+            this.getGlobalValue<UserInfo>('userInfo'),
+            this.getGlobalValue<TelemetrySetting>('telemetrySetting'),
+            this.getGlobalValue<boolean>('thinkingEnabled'),
+            this.getGlobalValue<boolean>('enableTabAutocomplete'),
+            this.getGlobalValue<string>('posthogHost'),
+            this.getGlobalValue<string>('posthogProjectId'),
+        ])
+
+        let apiProvider: ApiProvider
+        if (storedApiProvider) {
+            apiProvider = storedApiProvider
+        } else {
+            // Either new user or legacy user that doesn't have the apiProvider stored in state
+            apiProvider = 'anthropic'
+        }
+        let apiModelId: keyof typeof allModels
+        if (storedApiModelId) {
+            apiModelId = storedApiModelId as keyof typeof allModels
+        } else {
+            apiModelId = anthropicDefaultModelId
+        }
+        let completionApiProvider: CompletionApiProvider
+        if (storedCompletionApiProvider) {
+            completionApiProvider = storedCompletionApiProvider
+        } else {
+            completionApiProvider = 'codestral'
+        }
+        let posthogHost: string
+        if (storedPostHogHost) {
+            posthogHost = storedPostHogHost
+        } else {
+            posthogHost = 'https://us.posthog.com'
+        }
+        let chatSettings: ChatSettings
+        if (storedChatSettings) {
+            chatSettings = storedChatSettings
+            // ensure all modes are present
+            for (const mode of ['ask', 'plan', 'act'] as const) {
+                if (chatSettings[mode] === undefined) {
+                    chatSettings[mode] = {
+                        apiProvider,
+                        apiModelId,
+                        thinkingEnabled,
+                    }
+                }
+            }
+        } else {
+            chatSettings = {
+                mode: 'ask',
+                ask: {
+                    apiProvider,
+                    apiModelId,
+                    thinkingEnabled,
+                },
+                plan: {
+                    apiProvider,
+                    apiModelId,
+                    thinkingEnabled,
+                },
+                act: {
+                    apiProvider,
+                    apiModelId,
+                    thinkingEnabled,
+                },
+            }
+        }
+
+        const state: ExtensionStorageState = {
+            apiConfiguration: {
+                apiProvider,
+                completionApiProvider,
+                apiModelId,
+                posthogHost,
+                posthogApiKey,
+                posthogProjectId,
+                thinkingEnabled,
+            },
+            customInstructions,
+            taskHistory,
+            autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
+            browserSettings: browserSettings || DEFAULT_BROWSER_SETTINGS,
+            chatSettings,
+            userInfo,
+            telemetrySetting: telemetrySetting || 'unset',
+            enableTabAutocomplete,
+        }
+
+        this._cachedState = state
+        return state
+    }
+
+    async updateApiConfiguration(apiConfiguration: ApiConfiguration) {
+        const updatePromises = Object.entries(apiConfiguration)
+            .map(([key, value]) => {
+                const typedKey = key as keyof ApiConfiguration
+
+                if (value === undefined) {
+                    return null
+                }
+
+                if (typedKey === 'posthogApiKey') {
+                    return this.setSecretValue(typedKey, value)
+                }
+
+                return this.setGlobalValue(typedKey, value)
+            })
+            .filter(Boolean)
+
+        await Promise.all(updatePromises)
+    }
+
+    async clearAllData() {
+        const globalStatePromises = this.context.globalState
+            .keys()
+            .map((key) => this.context.globalState.update(key, undefined))
+
+        const secretKeys: SecretKey[] = ['posthogApiKey']
+        const secretPromises = secretKeys.map((key) => this.deleteSecretValue(key))
+
+        await Promise.all([...globalStatePromises, ...secretPromises])
+    }
+}


### PR DESCRIPTION
## Problem

Settings are now tightly coupled with the PostHogProvider. It makes them hard to use in other services or integrations.

## Changes

This PR decouples settings into a separate class, which can be injected into services or integrations as needed.

## How did you test this code?

Manual testing
